### PR TITLE
cbor encoding instead of candid

### DIFF
--- a/.github/workflows/kong_backend_tests.yml
+++ b/.github/workflows/kong_backend_tests.yml
@@ -12,6 +12,7 @@ jobs:
 
     env:
       CARGO_TERM_COLOR: always
+      GREP_OPTIONS: ""
 
     steps:
       - name: Checkout repository

--- a/src/kong_backend/src/solana/latest_blockhash.rs
+++ b/src/kong_backend/src/solana/latest_blockhash.rs
@@ -1,9 +1,10 @@
 use candid::{CandidType, Deserialize};
 use ic_stable_structures::{storable::Bound, Storable};
+use serde::Serialize;
 use std::borrow::Cow;
 
 /// Struct to store the latest blockhash and its timestamp (ic-time, in nanoseconds)
-#[derive(CandidType, Deserialize, Clone, Debug, Default)]
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
 pub struct LatestBlockhash {
     pub blockhash: String,
     pub timestamp_nanos: u64,
@@ -11,12 +12,11 @@ pub struct LatestBlockhash {
 
 impl Storable for LatestBlockhash {
     fn to_bytes(&self) -> Cow<[u8]> {
-        let bytes = candid::encode_one(self).expect("Failed to encode LatestBlockhash");
-        Cow::Owned(bytes)
+        serde_cbor::to_vec(self).expect("Failed to encode LatestBlockhash").into()
     }
 
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
-        candid::decode_one(&bytes).expect("Failed to decode LatestBlockhash")
+        serde_cbor::from_slice(&bytes).expect("Failed to decode LatestBlockhash")
     }
 
     const BOUND: Bound = Bound::Unbounded;

--- a/src/kong_backend/src/solana/mod.rs
+++ b/src/kong_backend/src/solana/mod.rs
@@ -7,3 +7,4 @@ pub mod sdk;
 pub mod signature_verification;
 pub mod transaction;
 pub mod transaction_types;
+pub mod utils;

--- a/src/kong_backend/src/solana/network.rs
+++ b/src/kong_backend/src/solana/network.rs
@@ -6,6 +6,7 @@ use std::fmt;
 use crate::ic::management_canister::ManagementCanister;
 
 use super::error::SolanaError;
+use super::utils::base58;
 
 // Known program IDs on Solana network
 pub const SYSTEM_PROGRAM_ID: &str = "11111111111111111111111111111111";
@@ -31,19 +32,12 @@ impl fmt::Display for SolanaNetwork {
 
 impl SolanaNetwork {
     pub fn bs58_encode_public_key(public_key: &[u8]) -> String {
-        bs58::encode(public_key).into_string()
+        base58::encode(public_key)
     }
 
     pub fn bs58_decode_public_key(public_key: &str) -> Result<[u8; 32]> {
-        let public_key = bs58::decode(public_key)
-            .into_vec()
-            .map_err(|_| SolanaError::InvalidPublicKeyFormat("Invalid public key format.".to_string()))?;
-
-        let validated_public_key = SolanaNetwork::validate_public_key(&public_key)?;
-
-        let mut arr = [0u8; 32];
-        arr.copy_from_slice(&validated_public_key);
-        Ok(arr)
+        base58::decode_public_key(public_key)
+            .map_err(|e| e.into())
     }
 
     pub async fn get_public_key(canister: &Principal) -> Result<String> {

--- a/src/kong_backend/src/solana/proxy/types.rs
+++ b/src/kong_backend/src/solana/proxy/types.rs
@@ -13,12 +13,11 @@ pub struct TransactionNotification {
 
 impl Storable for TransactionNotification {
     fn to_bytes(&self) -> Cow<[u8]> {
-        let bytes = candid::encode_one(self).expect("Failed to encode TransactionNotification");
-        Cow::Owned(bytes)
+        serde_cbor::to_vec(self).expect("Failed to encode TransactionNotification").into()
     }
 
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
-        candid::decode_one(&bytes).expect("Failed to decode TransactionNotification")
+        serde_cbor::from_slice(&bytes).expect("Failed to decode TransactionNotification")
     }
 
     const BOUND: Bound = Bound::Unbounded;

--- a/src/kong_backend/src/solana/sdk/signature.rs
+++ b/src/kong_backend/src/solana/sdk/signature.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use std::str::FromStr;
 
 use crate::solana::error::SolanaError;
+use crate::solana::utils::base58;
 
 /// Number of bytes in a signature
 pub const SIGNATURE_BYTES: usize = 64;
@@ -32,16 +33,7 @@ impl FromStr for Signature {
                 "Signature is wrong size".to_string(),
             ));
         }
-        let mut bytes = [0; SIGNATURE_BYTES];
-        let decoded_size = bs58::decode(s).onto(&mut bytes).map_err(|_| {
-            SolanaError::InvalidSignature("Signature is wrong base58 format".to_string())
-        })?;
-        if decoded_size != SIGNATURE_BYTES {
-            return Err(SolanaError::InvalidSignature(
-                "Signature is wrong size".to_string(),
-            ));
-        }
-
+        let bytes = base58::decode_signature(s)?;
         Ok(Signature(bytes))
     }
 }

--- a/src/kong_backend/src/solana/signature_verification.rs
+++ b/src/kong_backend/src/solana/signature_verification.rs
@@ -22,8 +22,10 @@ pub fn verify_ed25519_signature(
         return Err(SolanaError::InvalidSignature("Signature must be 64 bytes".to_string()).into());
     }
     
-    // Create signature from bytes
-    let signature = Signature::from_bytes(signature.try_into().unwrap());
+    // Create signature from bytes - handle conversion error properly
+    let signature_array: [u8; 64] = signature.try_into()
+        .map_err(|_| SolanaError::InvalidSignature("Failed to convert signature to 64-byte array".to_string()))?;
+    let signature = Signature::from_bytes(&signature_array);
     
     // Verify the signature
     Ok(verifying_key.verify(message, &signature).is_ok())

--- a/src/kong_backend/src/solana/transaction/builder.rs
+++ b/src/kong_backend/src/solana/transaction/builder.rs
@@ -9,6 +9,7 @@ use crate::solana::error::SolanaError;
 use crate::solana::network::{MEMO_PROGRAM_ID, SYSTEM_PROGRAM_ID, TOKEN_PROGRAM_ID};
 use crate::solana::sdk::account_meta::AccountMeta;
 use crate::solana::sdk::instruction::Instruction;
+use crate::solana::utils::validation;
 use crate::stable_memory::with_solana_latest_blockhash;
 
 /// Transaction instructions ready for signing
@@ -68,9 +69,7 @@ impl TransactionBuilder {
         memo: Option<String>,
     ) -> Result<TransactionInstructions> {
         // Validate addresses
-        if from_address.is_empty() || to_address.is_empty() {
-            Err(SolanaError::InvalidPublicKeyFormat("Invalid address for SOL transfer".to_string()))?
-        }
+        validation::validate_addresses(&[from_address, to_address])?;
 
         // Create the transfer instructions
         let transfer_instruction = self.create_transfer_sol_instruction(from_address, to_address, lamports)?;
@@ -140,9 +139,7 @@ impl TransactionBuilder {
         memo: Option<String>,
     ) -> Result<TransactionInstructions> {
         // Validate addresses
-        if owner_address.is_empty() || from_token_account.is_empty() || to_token_account.is_empty() {
-            Err(SolanaError::InvalidPublicKeyFormat("Invalid address for SPL transfer".to_string()))?
-        }
+        validation::validate_addresses(&[owner_address, from_token_account, to_token_account])?;
 
         // Create the transfer instructions
         let token_transfer_instruction =

--- a/src/kong_backend/src/solana/utils/base58.rs
+++ b/src/kong_backend/src/solana/utils/base58.rs
@@ -1,0 +1,41 @@
+use bs58;
+use super::super::error::SolanaError;
+
+/// Decode a base58-encoded public key into a 32-byte array
+pub fn decode_public_key(public_key: &str) -> Result<[u8; 32], SolanaError> {
+    let bytes = bs58::decode(public_key)
+        .into_vec()
+        .map_err(|_| SolanaError::InvalidPublicKeyFormat("Failed to decode base58".to_string()))?;
+    
+    if bytes.len() != 32 {
+        return Err(SolanaError::InvalidPublicKeyFormat(
+            format!("Expected 32 bytes, got {}", bytes.len())
+        ));
+    }
+    
+    let mut array = [0u8; 32];
+    array.copy_from_slice(&bytes);
+    Ok(array)
+}
+
+/// Decode a base58-encoded signature into a 64-byte array
+pub fn decode_signature(signature: &str) -> Result<[u8; 64], SolanaError> {
+    let bytes = bs58::decode(signature)
+        .into_vec()
+        .map_err(|_| SolanaError::InvalidSignature("Failed to decode base58".to_string()))?;
+    
+    if bytes.len() != 64 {
+        return Err(SolanaError::InvalidSignature(
+            format!("Expected 64 bytes, got {}", bytes.len())
+        ));
+    }
+    
+    let mut array = [0u8; 64];
+    array.copy_from_slice(&bytes);
+    Ok(array)
+}
+
+/// Encode bytes as base58 string
+pub fn encode(bytes: &[u8]) -> String {
+    bs58::encode(bytes).into_string()
+}

--- a/src/kong_backend/src/solana/utils/mod.rs
+++ b/src/kong_backend/src/solana/utils/mod.rs
@@ -1,0 +1,2 @@
+pub mod base58;
+pub mod validation;

--- a/src/kong_backend/src/solana/utils/validation.rs
+++ b/src/kong_backend/src/solana/utils/validation.rs
@@ -1,0 +1,17 @@
+use super::super::error::SolanaError;
+use super::base58;
+
+/// Validate a Solana address is well-formed
+pub fn validate_address(address: &str) -> Result<(), SolanaError> {
+    // Decode and validate it's 32 bytes
+    base58::decode_public_key(address)?;
+    Ok(())
+}
+
+/// Validate multiple addresses
+pub fn validate_addresses(addresses: &[&str]) -> Result<(), SolanaError> {
+    for address in addresses {
+        validate_address(address)?;
+    }
+    Ok(())
+}

--- a/src/kong_backend/src/swap/swap_job.rs
+++ b/src/kong_backend/src/swap/swap_job.rs
@@ -6,8 +6,8 @@ use std::borrow::Cow;
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Copy)]
 pub enum SwapJobStatus {
     PendingVerification, // Payment verification in progress
-    Pending,    // Job created, awaiting processing by ws_proxy
-    Confirmed,  // Confirmed by ws_proxy as successful on Solana
+    Pending,    // Job created, awaiting processing by kong_rpc
+    Confirmed,  // Confirmed by kong_rpc as successful on Solana
     Failed,     // Failed (either Solana tx failed, or an internal error)
 }
 
@@ -61,17 +61,17 @@ pub struct SwapJob {
     pub encoded_signed_solana_tx: String, 
     pub solana_tx_signature_of_payout: Option<String>,
     pub error_message: Option<String>,
-    pub attempts: u32, // For ws_proxy retry logic
+    pub attempts: u32, // For kong_rpc retry logic
     pub tx_sig: String, // Transaction signature computed at signing time
 }
 
 impl Storable for SwapJob {
     fn to_bytes(&self) -> Cow<[u8]> {
-        Cow::Owned(serde_json::to_vec(self).expect("Failed to serialize SwapJob"))
+        serde_cbor::to_vec(self).expect("Failed to encode SwapJob").into()
     }
 
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
-        serde_json::from_slice(bytes.as_ref()).expect("Failed to deserialize SwapJob")
+        serde_cbor::from_slice(&bytes).expect("Failed to decode SwapJob")
     }
     const BOUND: Bound = Bound::Unbounded; 
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced utility functions for base58 encoding and decoding of Solana public keys and signatures.
  - Added centralized validation functions for Solana addresses.

- **Refactor**
  - Centralized base58 encoding/decoding logic and address validation, replacing manual checks and direct crate usage across multiple modules.
  - Updated serialization for certain data structures to use CBOR format for improved efficiency and consistency.
  - Improved error handling in signature verification to replace panics with proper error propagation.

- **Documentation**
  - Updated comments to clarify job processing and retry logic.

- **Chores**
  - Adjusted environment variable settings and Rust toolchain version in backend test workflows.
  - Removed locked flag from backend build scripts.
  - Removed several unused dependencies from the backend project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->