### PR TITLE
Ft partial update pool

### DIFF
--- a/src/kong_backend/src/stable_kong_settings/stable_kong_settings.rs
+++ b/src/kong_backend/src/stable_kong_settings/stable_kong_settings.rs
@@ -86,7 +86,7 @@ impl Default for StableKongSettings {
             icp_address_with_chain: ICP_ADDRESS_WITH_CHAIN.to_string(),
             default_max_slippage: 2.0_f64,
             default_lp_fee_bps: 30,
-            default_kong_fee_bps: 0,
+            default_kong_fee_bps: 10,
             user_map_idx,
             token_map_idx,
             pool_map_idx,


### PR DESCRIPTION
## Description
Added partial pool update for simpler pool settings updates

Resolves https://github.com/kongzilla-ks/kong/issues/37. Also sets default `kong_fee_bps` to 10.

Added in comments some scripts that may be useful


## Checklist
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have adequate spec coverage of the changes and have manually tested them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for partial updates to pools, allowing selective field updates without replacing the entire pool.

* **Changes**
  * Updated the default value for the fee setting to 10 basis points (bps) instead of 0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->