### PR TITLE
Don't allow sending claims on disabled token

### DIFF
--- a/src/kong_backend/src/stable_claim/claim_map.rs
+++ b/src/kong_backend/src/stable_claim/claim_map.rs
@@ -61,6 +61,10 @@ pub fn update_too_many_attempts_status(claim_id: u64) -> Option<StableClaim> {
     update_status(claim_id, ClaimStatus::TooManyAttempts)
 }
 
+pub fn update_disabled_token(claim_id: u64) -> Option<StableClaim> {
+    update_status(claim_id, ClaimStatus::DisabledToken)
+}
+
 // used for setting the status of a claim to claimed after a successful claim
 pub fn update_claimed_status(claim_id: u64, request_id: u64, transfer_id: u64) -> Option<StableClaim> {
     CLAIM_MAP.with(|m| {

--- a/src/kong_backend/src/stable_claim/stable_claim.rs
+++ b/src/kong_backend/src/stable_claim/stable_claim.rs
@@ -25,6 +25,7 @@ pub enum ClaimStatus {
     Claiming, // used as a guard to prevent re-entrancy
     Claimed,
     TooManyAttempts,
+    DisabledToken,
     UnclaimedOverride,
     Claimable, // claim where user needs to call claim() to get the token
 }
@@ -36,6 +37,7 @@ impl std::fmt::Display for ClaimStatus {
             ClaimStatus::Claiming => write!(f, "Claiming"),
             ClaimStatus::Claimed => write!(f, "Success"),
             ClaimStatus::TooManyAttempts => write!(f, "TooManyAttempts"),
+            ClaimStatus::DisabledToken => write!(f, "DisabledToken"),
             ClaimStatus::UnclaimedOverride => write!(f, "UnclaimedOverride"),
             ClaimStatus::Claimable => write!(f, "Claimable"),
         }


### PR DESCRIPTION
## Description
<!-- Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues. -->

Relates to https://github.com/kongzilla-ks/kong/issues/35


## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have adequate spec coverage of the changes and have manually tested them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new claim status to indicate when a token is disabled. Claims with removed tokens are now clearly marked and archived.
* **Refactor**
  * Improved the handling and categorization of claims with removed tokens or excessive attempts, resulting in clearer claim statuses and processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->